### PR TITLE
Fix for AUTHENTICATION Key Error

### DIFF
--- a/dynamite_sdk/__init__.py
+++ b/dynamite_sdk/__init__.py
@@ -16,14 +16,6 @@ class ConfigNotFound(Exception):
 
 paths = ['config.cfg', '/etc/dynamite/dynamite_sdk/config.cfg']
 
-found = False
-for path in paths:
-    try:
-        config.read(path)
-        found = True
-        break
-    except FileNotFoundError:
-        pass
-if not found:
+config.read(paths)
+if 'AUTHENTICATION' not in config:
     raise ConfigNotFound(paths)
-


### PR DESCRIPTION
I was continuously getting a Key Error when trying to execute any search.  Traced the issue back to __init__.py where the config file is getting loaded.  After some digging found that `ConfigParser.read()` doesn't raise a FileNotFoundError it just ignores anything it can't find (e.g. `config.cfg` in the local directory).  So we're never actually getting to the except block in the below.  `config.read` would run without error, `found` would get set to True and the loop would break.  Later `dynamite_sdk.search.Search` would fail when it attempted to access the AUTHENTICATION key since it wasn't there.   

```
paths = ['config.cfg', '/etc/dynamite/dynamite_sdk/config.cfg']

for path in paths:
    try:
        config.read(path)
        found = True
        break
    except FileNotFoundError:
        pass
```

I also found out that `ConfigParser.read()` accepts an iterable, so we can pass in `paths` directly.  It'll skip the local config.cfg if it can't be found and load the one in `/etc/dynamite/dynamite_sdk`.  Finally, added a condition to check that the AUTHENTICATION key is present in the loaded config and raise the exception if not.  